### PR TITLE
Add unit tests

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcresultowners.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcresultowners.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Tests"
+               BuildableName = "Tests"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "IndexStoreDB", package: "indexstore-db")
             ]
+        ),
+        .testTarget(
+            name: "Tests",
+            dependencies: ["xcresultowners"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -30,12 +30,10 @@ This project supplements the test results summary produced by [`xcresulttool`](h
 
 #### Locate tests using `IndexStoreDB`
 ```shell
- swift run xcresultowners locate-tests \
+ swift run xcresultowners locate-test \
    --library-path  $(xcodebuild -find-library libIndexStore.dylib) \
    --store-path    <path-to-derived-data-directory-of-target> + "/Index.noindex/DataStore" \
-   <test-identifier-from-xcresults-file> \
-   <test-identifier-from-xcresults-file>
-   ...
+   <module-name> <test-identifier-from-xcresults-file>
 ```
 
 #### Comprehensive USAGE details
@@ -51,8 +49,8 @@ swift run xcresultowners help
    xcrun xcresulttool get test-results summary --path <path-to-xcresult-bundle> 
    ```
    
-   The output includes a `testIdentifierString` and `testIdentifierURL` for each failing test case that encodes all types that a test case is nested within including the module name. 
-1. Since the `testIdentifierString` is not a location of a file, this needs to be mapped to a file path. Under the hood, Xcode uses the open-sourced [indexstore-db](https://github.com/swiftlang/indexstore-db) project (available as a swift package) for features such as symbol lookups and code completion. This library can be leveraged to search for symbol occurrences, then use their symbol [`USRs`](https://github.com/swiftlang/swift/blob/main/docs/Lexicon.md#usr) to find the occurrence that precisely matches a `testIdentifierString` or a `testIdentifierURL`. `indexstore-db` provides rich information about the occurrence that includes its role, kind, file path, line number etc. 
+   The output includes a `testIdentifierString` and `targetName` for each failing test case. 
+1. Since the `testIdentifierString` is not a location of a file, this needs to be mapped to a file path. Under the hood, Xcode uses the open-sourced [indexstore-db](https://github.com/swiftlang/indexstore-db) project (available as a swift package) for features such as symbol lookups and code completion. This library can be leveraged to locate the test case represented by `testIdentifierString`. 
 1. Once the location where the test case is defined is determined, we can use information (patterns and associated team mentions) in the GitHub `CODEOWNERS` file generate a list of owners for every file in a repository and determine a definitive list of owners of the test case in question. For pattern matching (globbing), we use POSIX standard's [`fnmatch`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fnmatch.html) that is natively available in `Swift`.
 
 ## Road to v1.0

--- a/Sources/IndexStoreDB+Async.swift
+++ b/Sources/IndexStoreDB+Async.swift
@@ -1,7 +1,7 @@
 import Foundation
 import IndexStoreDB
 
-extension IndexStoreDB {
+public extension IndexStoreDB {
     /// Initializes IndexStoreDB with a temporary directory.
     /// - Parameters:
     ///   - storePath: The path to the store. Located in derivedData folder at `Index.noindex/DataStore`

--- a/Sources/IndexStoreDB+Locate.swift
+++ b/Sources/IndexStoreDB+Locate.swift
@@ -12,11 +12,19 @@ public extension IndexStoreDB {
             ignoreCase: false
         )
 
-        let occurrence = occurrences.first {
-            $0.location.moduleName == moduleName && symbolIdentifier($0) == testIdentifier
+        let moduleDefinitions = occurrences.filter {
+            $0.roles.contains(.definition) &&
+            $0.location.moduleName == moduleName
         }
 
-        return occurrence?.location
+        // if there are more than 1 matches, use testIdentifier to find a match.
+        let definition = if moduleDefinitions.count > 1 {
+            moduleDefinitions.first { symbolIdentifier($0) == testIdentifier }
+        } else {
+            moduleDefinitions.first
+        }
+
+        return definition?.location
     }
 }
 

--- a/Sources/IndexStoreDB+Locate.swift
+++ b/Sources/IndexStoreDB+Locate.swift
@@ -3,68 +3,35 @@ import IndexStoreDB
 
 public extension IndexStoreDB {
     /// Returns the location of the test case
-    func locate(testCaseName: String, testIdentifier: String, moduleName: String?) -> SymbolLocation? {
-        canonicalOccurrences(
+    func locate(testCaseName: String, testIdentifier: String, moduleName: String) -> SymbolLocation? {
+        let occurrences = canonicalOccurrences(
             containing: testCaseName,
             anchorStart: true,
             anchorEnd: false,
-            subsequence: true,
+            subsequence: false,
             ignoreCase: false
         )
-        .unitTestDefinitions(inModule: moduleName)
-        .bestMatch(using: testIdentifier)?
-        .location
+
+        let occurrence = occurrences.first {
+            $0.location.moduleName == moduleName && symbolIdentifier($0) == testIdentifier
+        }
+
+        return occurrence?.location
     }
 }
 
-extension [SymbolOccurrence] {
-    /// Returns a filtered array containing occurrences of unit test definitions in a module
-    func unitTestDefinitions(inModule moduleName: String?) -> [SymbolOccurrence] {
-        filter {
-            $0.roles.contains(.definition)
-        }
-        .filter {
-            // further filter by module name if provided
-            if let moduleName {
-                moduleName == $0.location.moduleName
-            } else {
-                true
-            }
-        }
-    }
-
-    /// Returns the best match using information in the `testIdentifier`
-    func bestMatch(using testIdentifier: String) -> SymbolOccurrence? {
-        guard let testIdentifierURL = URL(string: testIdentifier) else {
-            return nil
-        }
-
-        // Ignore the last path component which is the test case name
-        let components = testIdentifierURL
-            .deletingLastPathComponent()
-            .pathComponents
-
-        // Score the occurrences based on how much they match the testIdentifier components
-        let scoredOccurrences = map { occurrence -> (occurrence: SymbolOccurrence, score: Int) in
-
-            // the USR (Unified Symbol Resolution) contains identifier components that can be used to find the best match
-            // https://github.com/swiftlang/swift/blob/main/docs/Lexicon.md#usr
-            //
-            // Example:
-            // identifier = "RouterTests/testPresentTwice()"
-            // usr = "c:@M@XINGTests@objc(cs)RouterTests(im)testPresentTwiceAndReturnError:"
-            //
-            let matchedComponents = components.count {
-                occurrence.symbol.usr.contains($0)
-            }
-
-            return (occurrence: occurrence, score: matchedComponents)
-        }
-
-        // Return the occurrence with the best score
-        return scoredOccurrences
-            .sorted { $0.score > $1.score }
-            .map(\.occurrence)
+extension IndexStoreDB {
+    /// A unique identifier for a symbol that corresponds to a `testIdentifierString` from a `xcresult` bundle
+    func symbolIdentifier(_ occurrence: SymbolOccurrence) -> String {
+        let parentUSR = occurrence.relations
+            .filter { $0.roles.contains(.childOf) }
+            .map { $0.symbol.usr }
             .first
+
+        if let parentUSR, let parentDefinition = occurrences(ofUSR: parentUSR, roles: .definition).first {
+            return symbolIdentifier(parentDefinition) + "/" + occurrence.symbol.name
+        } else {
+            return occurrence.symbol.name
+        }
     }
 }

--- a/Sources/IndexStoreDB+Locate.swift
+++ b/Sources/IndexStoreDB+Locate.swift
@@ -21,7 +21,6 @@ extension [SymbolOccurrence] {
     /// Returns a filtered array containing occurrences of unit test definitions in a module
     func unitTestDefinitions(inModule moduleName: String?) -> [SymbolOccurrence] {
         filter {
-            $0.symbol.properties.contains(.unitTest) &&
             $0.roles.contains(.definition)
         }
         .filter {

--- a/Sources/IndexStoreDB+Locate.swift
+++ b/Sources/IndexStoreDB+Locate.swift
@@ -1,7 +1,7 @@
 import Foundation
 import IndexStoreDB
 
-extension IndexStoreDB {
+public extension IndexStoreDB {
     /// Returns the location of the test case
     func locate(testCaseName: String, testIdentifier: String, moduleName: String?) -> SymbolLocation? {
         canonicalOccurrences(

--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -16,7 +16,7 @@ extension Output {
     /// Returns the json representation of the report
     func jsonFormatted() throws -> String {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted]
+        encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes, .sortedKeys]
         let data = try encoder.encode(self)
         return String(decoding: data, as: UTF8.self)
     }

--- a/Sources/OwnedFile.swift
+++ b/Sources/OwnedFile.swift
@@ -35,7 +35,7 @@ func resolveFileOwners(repositoryURL: URL) async throws -> [OwnedFile] {
         }
         .compactMap {
             /// Use code owner patterns to resolve a fileURL to an `OwnedFile`
-            resolveToOwnedFile(fileURL: $0, codeOwners: codeOwnersPatterns ?? [])
+            resolveToOwnedFile(fileURL: $0, codeOwners: codeOwnersPatterns)
         }
 
     logToStandardError("Resolving file owners... ✓")

--- a/TestData/.gitignore
+++ b/TestData/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/TestData/Package.swift
+++ b/TestData/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestProject",
+    products: [],
+    targets: [
+        .target(name: "ModuleA"),
+        .target(name: "ModuleB"),
+        .testTarget(name: "ModuleATests", dependencies: ["ModuleA"]),
+        .testTarget(name: "ModuleBTests", dependencies: ["ModuleB"])
+    ]
+)

--- a/TestData/Sources/ModuleA/FileA.swift
+++ b/TestData/Sources/ModuleA/FileA.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/TestData/Sources/ModuleA/FileA.swift
+++ b/TestData/Sources/ModuleA/FileA.swift
@@ -1,2 +1,20 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
+
+struct Level1 {
+    struct Level2 {
+        struct Level3 {
+            struct Level4 {
+                struct Level5 {
+                    struct Level6 {
+                        struct Level7 {
+                            func foo() {
+
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TestData/Sources/ModuleB/FileB.swift
+++ b/TestData/Sources/ModuleB/FileB.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+

--- a/TestData/Tests/ModuleATests/SampleSwiftTests.swift
+++ b/TestData/Tests/ModuleATests/SampleSwiftTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import ModuleA
+
+@Test func topLevelTest() async throws {}
+
+struct SampleSwiftTests {
+    @Test func foo() async throws {}
+    @Test func bar() async throws {}
+    @Test func testFoo() async throws {}
+    @Test func testBar() async throws {}
+
+
+    class NestedSwiftTests {
+        @Test func foo() async throws {}
+        @Test func bar() async throws {}
+        @Test func testFoo() async throws {}
+        @Test func testBar() async throws {}
+    }
+}

--- a/TestData/Tests/ModuleATests/SampleXCTests.swift
+++ b/TestData/Tests/ModuleATests/SampleXCTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+final class SampleXCTests: XCTestCase {
+    func testFoo() {}
+    func testBar() {}
+
+    final class SampleNestedXCTests: XCTestCase {
+        func testFoo() {}
+        func testBar() {}
+    }
+}

--- a/TestData/Tests/ModuleBTests/SampleSwiftTests.swift
+++ b/TestData/Tests/ModuleBTests/SampleSwiftTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import ModuleB
+
+@Test func topLevelTest() async throws {}
+
+struct SampleSwiftTests {
+    @Test func foo() async throws {}
+    @Test func bar() async throws {}
+    @Test func testFoo() async throws {}
+    @Test func testBar() async throws {}
+
+
+    class NestedSwiftTests {
+        @Test func foo() async throws {}
+        @Test func bar() async throws {}
+        @Test func testFoo() async throws {}
+        @Test func testBar() async throws {}
+    }
+}

--- a/TestData/Tests/ModuleBTests/SampleXCTests.swift
+++ b/TestData/Tests/ModuleBTests/SampleXCTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+final class SampleXCTests: XCTestCase {
+    func testFoo() {}
+    func testBar() {}
+
+    final class SampleNestedXCTests: XCTestCase {
+        func testFoo() {}
+        func testBar() {}
+    }
+}

--- a/Tests/IndexStoreDB+Locate.swift
+++ b/Tests/IndexStoreDB+Locate.swift
@@ -9,8 +9,8 @@ struct LocateTests {
     @Test func locateTopLevelSwiftTest() async throws {
         let location = IndexStoreDB.suiteShared?.locate(
             testCaseName: "topLevelTest()",
-            testIdentifier: "ModuleATests/topLevelTest()",
-            moduleName: nil
+            testIdentifier: "topLevelTest()",
+            moduleName: "ModuleATests"
         )
 
         #expect(location?.moduleName == "ModuleATests")
@@ -21,8 +21,8 @@ struct LocateTests {
     @Test func locateSwiftTest() async throws {
         let location = IndexStoreDB.suiteShared?.locate(
             testCaseName: "foo()",
-            testIdentifier: "ModuleATests/SampleSwiftTests/foo()",
-            moduleName: nil
+            testIdentifier: "SampleSwiftTests/foo()",
+            moduleName: "ModuleATests"
         )
 
         #expect(location?.moduleName == "ModuleATests")
@@ -33,8 +33,8 @@ struct LocateTests {
     @Test func locateNestedSwiftTest() async throws {
         let location = IndexStoreDB.suiteShared?.locate(
             testCaseName: "foo()",
-            testIdentifier: "ModuleATests/SampleSwiftTests/NestedSwiftTests/foo()",
-            moduleName: nil
+            testIdentifier: "SampleSwiftTests/NestedSwiftTests/foo()",
+            moduleName: "ModuleATests"
         )
 
         #expect(location?.moduleName == "ModuleATests")
@@ -45,8 +45,8 @@ struct LocateTests {
     @Test func locateSwiftTestWithTestPrefix() async throws {
         let location = IndexStoreDB.suiteShared?.locate(
             testCaseName: "testFoo()",
-            testIdentifier: "ModuleATests/SampleSwiftTests/testFoo()",
-            moduleName: nil
+            testIdentifier: "SampleSwiftTests/testFoo()",
+            moduleName: "ModuleATests"
         )
 
         #expect(location?.moduleName == "ModuleATests")

--- a/Tests/IndexStoreDB+Locate.swift
+++ b/Tests/IndexStoreDB+Locate.swift
@@ -1,0 +1,68 @@
+import Testing
+import Foundation
+import IndexStoreDB
+@testable import xcresultowners
+
+@Suite(.serialized)
+struct LocateTests {
+    @Test func locateTopLevelSwiftTest() async throws {
+        let location = try await makeIndexStoreDB()
+            .locate(
+                testCaseName: "topLevelTest()",
+                testIdentifier: "ModuleATests/topLevelTest()",
+                moduleName: nil
+            )
+
+        #expect(location?.moduleName == "ModuleATests")
+        #expect(location?.path.hasSuffix("TestData/Tests/ModuleATests/SampleSwiftTests.swift") == true)
+        #expect(location?.line == 4)
+    }
+
+    @Test func locateSwiftTest() async throws {
+        let location = try await makeIndexStoreDB()
+            .locate(
+                testCaseName: "foo()",
+                testIdentifier: "ModuleATests/SampleSwiftTests/foo()",
+                moduleName: nil
+            )
+
+        #expect(location?.moduleName == "ModuleATests")
+        #expect(location?.path.hasSuffix("TestData/Tests/ModuleATests/SampleSwiftTests.swift") == true)
+        #expect(location?.line == 7)
+    }
+
+    @Test func locateNestedSwiftTest() async throws {
+        let location = try await makeIndexStoreDB()
+            .locate(
+                testCaseName: "foo()",
+                testIdentifier: "ModuleATests/SampleSwiftTests/NestedSwiftTests/foo()",
+                moduleName: nil
+            )
+
+        #expect(location?.moduleName == "ModuleATests")
+        #expect(location?.path.hasSuffix("TestData/Tests/ModuleATests/SampleSwiftTests.swift") == true)
+        #expect(location?.line == 14)
+    }
+
+    @Test func locateSwiftTestWithTestPrefix() async throws {
+        let location = try await makeIndexStoreDB()
+            .locate(
+                testCaseName: "testFoo()",
+                testIdentifier: "ModuleATests/SampleSwiftTests/testFoo()",
+                moduleName: nil
+            )
+
+        #expect(location?.moduleName == "ModuleATests")
+        #expect(location?.path.hasSuffix("TestData/Tests/ModuleATests/SampleSwiftTests.swift") == true)
+        #expect(location?.line == 9)
+    }
+}
+
+// MARK: -
+
+func makeIndexStoreDB() async throws -> IndexStoreDB {
+    try await IndexStoreDB(
+        storePath: TestData.testProjectIndexStorePath(),
+        libraryPath: TestData.indexStoreLibraryPath()
+    )
+}

--- a/Tests/TestData.swift
+++ b/Tests/TestData.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+class TestData {
+
+    static func indexStoreLibraryPath() throws -> String {
+        try shell("xcodebuild -find-library libIndexStore.dylib")
+    }
+
+    static func testProjectIndexStorePath() throws -> String {
+        let buildPath = try shell("swift build --package-path \(testProjectPath) --show-bin-path")
+        _ = try shell("rm -rf \(buildPath)")
+        _ = try shell("swift build --package-path \(testProjectPath) --build-tests")
+        return buildPath + "/index/store"
+    }
+
+    private static var testProjectPath: String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "TestData")
+            .path()
+    }
+
+    private static func shell(_ command: String) throws -> String {
+        let standardOutput = Pipe()
+        let process = Process()
+        process.executableURL = URL(filePath: "/bin/bash")
+        process.arguments = ["-c", command]
+        process.standardOutput = standardOutput
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = standardOutput.fileHandleForReading.availableData
+        let outputString = String(decoding: outputData, as: UTF8.self)
+        return outputString.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
- Adds some unit tests
- Unit tests identified that the `USR` is not sufficient to match `testIdentifierString` to a `Symbol`
  - The logic to locate a test case has been changed to use more symbol lookups to find the right match for the identifier.  